### PR TITLE
Release version 2.0.1

### DIFF
--- a/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/Content.java
+++ b/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/Content.java
@@ -210,15 +210,15 @@ public class Content {
             }
 
             Hotspot(String x, String y) {
-                this((int) Integer.parseInt(x), (int) Integer.parseInt(y));
+                this(Integer.parseInt(x), Integer.parseInt(y));
             }
 
             Hotspot(int x, String y) {
-                this(x, (int) Integer.parseInt(y));
+                this(x, Integer.parseInt(y));
             }
 
             Hotspot(String x, int y) {
-                this((int) Integer.parseInt(x), y);
+                this(Integer.parseInt(x), y);
             }
 
             @Override

--- a/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/SettingsFragment.java
+++ b/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/SettingsFragment.java
@@ -44,7 +44,8 @@ public class SettingsFragment
         mAlien = findPreference(ALIEN_RACE);
         mScaling = findPreference(SCALING);
         Preference mVersion = findPreference(VERSION);
-        mVersion.setSummary(getVersionName(getContext()));
+        if (mVersion != null)
+            mVersion.setSummary(getVersionName(getContext()));
 
         String buf;
         prefs = getPreferenceManager().getSharedPreferences();

--- a/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/UQMWallpaper.java
+++ b/UQMLiveWallpaper/src/main/java/net/submedia/android/uqmwallpaper/UQMWallpaper.java
@@ -50,7 +50,6 @@ public class UQMWallpaper
     private final Handler mHandler = new Handler();
     private Context mContext;
     private Width totalWidth;
-    private int totalHeight;
     private int mUserOffset;
 
     @Override
@@ -60,7 +59,8 @@ public class UQMWallpaper
         // what odd method names for these...
         WallpaperManager wm = WallpaperManager.getInstance(mContext);
         totalWidth = new Width(wm.getDesiredMinimumWidth());
-        totalHeight = wm.getDesiredMinimumHeight();
+        // this may need to be up-sold to a class variable
+        int totalHeight = wm.getDesiredMinimumHeight();
         Log.d(TAG, String.format("totalWidth: %04d totalHeight: %04d", totalWidth.full, totalHeight));
 
     }
@@ -75,7 +75,7 @@ public class UQMWallpaper
         return new CommsEngine();
     }
 
-    private class Width {
+    private static class Width {
         public int full;
         public int half;
 
@@ -100,16 +100,12 @@ public class UQMWallpaper
         private Animation mAnim;
         private int mScaling = 2;
         private boolean mVisible;
-        private final Runnable mDrawComms = new Runnable() {
-            public void run() {
-                drawFrame();
-            }
-        };
+        private final Runnable mDrawComms = this::drawFrame;
 
         CommsEngine() {
             mPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
             mPrefs.registerOnSharedPreferenceChangeListener(this);
-            onSharedPreferenceChanged(mPrefs, null);
+            onSharedPreferenceChanged(mPrefs, OFFSET_PREF);
             Log.v(TAG, "started");
         }
 
@@ -243,7 +239,7 @@ public class UQMWallpaper
                 default:
                     return;
             }
-            Log.d(TAG, String.format("mAnchor (%04d) moffset(%04d)", mAnchor, mOffset));
+            Log.d(TAG, String.format("mAnchor (%04d) mOffset(%04d)", mAnchor, mOffset));
         }
 
         /*

--- a/UQMLiveWallpaper/src/main/res/values/slyhome.xml
+++ b/UQMLiveWallpaper/src/main/res/values/slyhome.xml
@@ -3,6 +3,7 @@
 <resources>
   <string-array name="slyhome_content">
     <item>slyhome</item>
+    <item>slylandro</item>
   </string-array>
   <integer-array name="slyhome_anim0">
     <item>0</item>

--- a/UQMLiveWallpaper/src/main/res/values/slyland.xml
+++ b/UQMLiveWallpaper/src/main/res/values/slyland.xml
@@ -2,6 +2,7 @@
 <!-- auto-generated from src/sc2code/comm/slyland/slyland.c -->
 <resources>
   <string-array name="slyland_content">
+    <item>probe</item>
     <item>slyland</item>
     <item>slylandro</item>
   </string-array>

--- a/UQMLiveWallpaper/src/main/res/values/spahome.xml
+++ b/UQMLiveWallpaper/src/main/res/values/spahome.xml
@@ -3,6 +3,7 @@
 <resources>
   <string-array name="spahome_content">
     <item>spahome</item>
+    <item>safeones</item>
   </string-array>
   <integer-array name="spahome_anim0">
     <item>1</item>

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/tools/mkresources.py
+++ b/tools/mkresources.py
@@ -96,7 +96,7 @@ def main(input_file, temp_file):
 			outfh = open(_.expand(r"%s\1.xml" % race), "w")
 		else:
 			outfh = open(r"%s.xml" % race, "w")
-		print >> outfh, "<!-- auto-generated from %s -->" % input_file
+		print("<!-- auto-generated from %s -->" % input_file, file=outfh)
 
 		output = xml.Element("resources")
 		# used for populating a lookup table array later
@@ -142,7 +142,7 @@ def main(input_file, temp_file):
 		# The money shot
 		xml.ElementTree(output).write(outfh, encoding="utf-8")
 		outfh.close()
-		print "wrote %s" % outfh.name
+		print("wrote %s" % outfh.name)
 
 		# Post-process through the shell command:
 		# "xmllint --format --encode utf-8" for pretty-printing
@@ -273,7 +273,7 @@ class Emit(object):
 
 if __name__ == "__main__":
 	if len(sys.argv) < 2:
-		print >> sys.stderr, __doc__
+		print(__doc__, file=sys.stderr)
 		sys.exit(1)
 
 	tmpf, tmp = tempfile.mkstemp(suffix=".h", dir=".")


### PR DESCRIPTION
Administriva: Update builds to use Gradle 4.2.0

Administriva: Switch builds to stop pulling dependencies from JCenter, as it's EOL

Cleanup: Convert the old mkresources.py script to Python 3

Bugfix: Update content definitions for Slylandro, Probes, and Safe Ones to match the 0.8.x content packs

Bugfix: Wallpaper offset is now remembered across device restarts

Trivial Java cleanups (null pointer checks, remove useless casts, etc.)